### PR TITLE
a few changes 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ inside a docker container.
 This playbook tests only a few selected modules.
 * `data/`: Data files
     - `data/boltron.cfg`: The Boltron compose configuration file.
-    - `data/build-image.cfg`: A bash script to create a docker image. To be replaced with Ansible playbook. See Issue #2.
+    - `data/build-image.sh`: A bash script to create a docker image. To be replaced with an Ansible playbook. See Issue #2.
     - `data/insecure_private_key`: A key to ssh connect to the Vagrant machine.
 * `Vagrantfile`: A file to provision the Vagrant machine. Most of it will be replaced with Ansilbe playbook. See Issue #1.
 
@@ -27,7 +27,7 @@ Usage
 * Navigate there
 * As a sudo user run:
 ```
-ansible-playbook deploy.yaml  --extra-vars "compose=LINK/TO/TESTED/COMPOSE"
+ansible-playbook deploy.yaml  --extra-vars "compose=LINK/TO/COMPOSE/TO/TEST"
 ```
 
 __Mind the mandatory extra variable `compose`__ It can be a koji url link or a name of the container, e.g: 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,13 +2,13 @@ Vagrant.configure(2) do |config|
   config.vm.box = "fedora/26-cloud-base"
   config.ssh.insert_key = false
   config.vm.hostname = "fvagrant"
-  config.vm.define :vagrant_module_builder do |vagrant_host|
+  config.vm.define :vagrant_module_tester do |vagrant_host|
     vagrant_host.vm.provider :libvirt do |domain|
       #domain.cpus = 1
       #domain.memory = 16384
       domain.memory = 1024
       domain.nested = true
-      domain.cpu_mode = "host-model"
+      #domain.cpu_mode = "host-model" #having this flag set makes the vm not launch for me --langdon
     end
 
     vagrant_host.vm.provision "shell", inline: "sudo dnf -y update"

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -6,24 +6,31 @@
 - name:  Vagrant installation
   hosts: localhost
   connection: local
-  become: yes
-  become_method: sudo
+  #running the whole playbook as root made vagrant want to run as root, 
+  #   which was causing me no end of problems
+  
   tasks:
 
     - name: install vagrant
       package:
         name: vagrant
         state: present
+      become: yes
+      become_method: sudo
 
     - name: install vagrant-libvirt
       package:
         name: vagrant-libvirt
         state: present
+      become: yes
+      become_method: sudo
 
     - name: start libvirtd service
       service:
         name: libvirtd
         state: started
+      become: yes
+      become_method: sudo
     
     - name: provision vagrant evironment, it can take 5-10 minutes
       command: vagrant up --provider=libvirt
@@ -87,6 +94,6 @@
            - /vagrant/run-tests.sh:/run-tests.sh:z
         command: sleep infinity
 
-    - import_tasks: tests/quick_mini_test.yaml
-    - import_tasks: tests/modules_install.yaml
-    - import_tasks: tests/modules_update.yaml
+    - include: tests/quick_mini_test.yaml
+    - include: tests/modules_install.yaml
+    - include: tests/modules_update.yaml


### PR DESCRIPTION
* minor text changes in readme
* removed host-model pass through in vagrantfile as it was causing me problems (unless required these things should not be set and left to the user instead). May want to consider removing the nested flag as well to not block on machines without nested virt. Personally, I would just drop the whole libvirt block as it isn't required. It was in the source to be able to bump the ram up for module development.
* modified commands to only run the nec. things as root on the user machine, vagrant should be run as a normal user and, for me, it was pretty busted trying to run as root
* modified vagrantfile to give the generated vm a more sane name 
* modified import_tasks to include to work with f26 version of ansible (wouldn't modularity be great?)