### PR TITLE
Add cico tests

### DIFF
--- a/.cico.yaml
+++ b/.cico.yaml
@@ -1,0 +1,83 @@
+- trigger:
+    name: periodic
+    triggers:
+        - timed: "@daily"
+
+- scm:
+    name: git-scm
+    scm:
+        - git:
+            url: "{git_url}"
+            skip-tag: True
+            git-tool: ci-git
+
+- job-template:
+    name: '{ci_project}-{git_repo}'
+    description: |
+        Managed by Jenkins Job Builder, do not edit manually!
+    node: "{ci_project}"
+    properties:
+        - github:
+            url: https://github.com/{git_username}/{git_repo}/
+    scm:
+        - git-scm:
+            git_url: https://github.com/{git_username}/{git_repo}.git
+    triggers:
+        - periodic
+    auth-token: fedora-qa
+    builders:
+        - shell: |
+            set +e
+            export CICO_API_KEY=$(cat ~/duffy.key )
+            # get node
+            n=1
+            while true
+            do
+                cico_output=$(cico node get -f value -c ip_address -c comment)
+                if [ $? -eq 0 ]; then
+                    read CICO_hostname CICO_ssid <<< $cico_output
+                    if  [ ! -z "$CICO_hostname" ]; then
+                        # we got hostname from cico
+                        break
+                    fi
+                    echo "'cico node get' succeed, but can't get hostname from output"
+                fi
+                if [ $n -gt 5 ]; then
+                    # give up after 5 tries
+                    echo "giving up on 'cico node get'"
+                    exit 1
+                fi
+                echo "'cico node get' failed, trying again in 60s ($n/5)"
+                n=$[$n+1]
+                sleep 60
+            done
+            sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
+            ssh_cmd="ssh $sshopts $CICO_hostname"
+            # Save the jenkins environment if needed
+            env > jenkins-env
+            $ssh_cmd yum -y install rsync
+            rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload \
+            && /usr/bin/timeout {timeout} $ssh_cmd -t 'cd payload && {ci_cmd}'
+            rtn_code=$?
+            if [ $rtn_code -eq 0 ]; then
+                cico node done $CICO_ssid
+            else
+                if [[ $rtn_code -eq 124 ]]; then
+                   echo "BUILD TIMEOUT";
+                   cico node done $CICO_ssid
+                else
+                    # fail mode gives us 12 hrs to debug the machine
+                    curl "http://admin.ci.centos.org:8080/Node/fail?key=$CICO_API_KEY&ssid=$CICO_ssid"
+                fi
+            fi
+            exit $rtn_code
+
+- project:
+    name: fedora-qa
+    jobs:
+        - '{ci_project}-{git_repo}':
+            git_username: alexxa
+            git_repo: compose_tester
+            ci_project: fedora-qa
+            ci_cmd: 'yum -y install ansible && ansible-playbook deploy.yaml  --extra-vars "compose=registry.fedoraproject.org/f26-modular/boltron"'
+            timeout: '20m'

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -5,4 +5,3 @@ statici = yes
 
 [privilege_escalation]
 become_method=sudo
-become_ask_pass=True

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -16,7 +16,6 @@
     - name: install docker
       package:
         name: docker
-        enablerepo: "*"
         state: present
 
     - name: start docker service
@@ -36,7 +35,6 @@
     - name: install python-docker-py to use docker_container
       package:
         name: python-docker-py
-        enablerepo: "*"
         state: latest
 
     - name: create a data container


### PR DESCRIPTION
This PR adds a job to ci.centos.org and tweaks a couple of things to make it easier to run automatically: 
- Assume that the machine is provisioned with the necessary repos, we don't need to enable them in the packaging step (CentOS ships with some disabled repos that can cause funny things to happen if they all get enabled at once)

- Assume that we either have root privileges or ask for a sudo password by passing `-K` to ansible-playbook

Once this is merged we can figure out how to trigger this on the proper fedmsgs.